### PR TITLE
解决util/proxy/frame.js报错问题

### DIFF
--- a/src/util/ajax/proxy/frame.js
+++ b/src/util/ajax/proxy/frame.js
@@ -39,14 +39,17 @@ NEJ.define([
             _init = !1;
         // receive message
         var _doReceiveMessage = function(_event){
-            var _data = _event.data;
-            if (_data.indexOf(_flag)!=0) return;
-            _data = JSON.parse(_data.replace(_flag,''));
-            var _proxy = _cache[_data.key];
-            if (!_proxy) return;
-            delete _cache[_data.key];
-            _data.result = decodeURIComponent(_data.result||'');
-            _proxy.__onLoadRequest(_data);
+            try{
+                var _data = _event.data;
+                if(typeof _data !== 'string') return;
+                if (_data.indexOf(_flag)!=0) return;
+                _data = JSON.parse(_data.replace(_flag,''));
+                var _proxy = _cache[_data.key];
+                if (!_proxy) return;
+                delete _cache[_data.key];
+                _data.result = decodeURIComponent(_data.result||'');
+                _proxy.__onLoadRequest(_data);
+            }catch(e) {}
         };
         // init message listener
         var _doInitMessage = function(){


### PR DESCRIPTION
iframe的方式发起请求，会监听window上的message事件。
其他的iframe也可能会触发该事件，造成nej的frame.js报错。